### PR TITLE
Add item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,25 @@ then create the client with
 ```
 
 ### Concepts
-Stories, comments, jobs, asks and polls are all "items" and `Item(id string) (interface{}, error)` encourages you to assert the type of the item returned:
-
+Stories, comments, jobs, asks and polls are all "items". `Item` contains a superset of the properties in each subtype. Helpers like `GetComment` can help reduce Item into a more specific Comment type.
 #### Items
+##### Item
+Field | Type | Description
+------|------|------------
+By      | `string`    | The username of the story's author
+Delete | `bool` | If this item has been deleted
+Dead | `bool` | If this item has been marked Dead
+ID      | `int`       | This story's item id
+Descendants | `int`   | The total comment count
+Kids    | `[]int`     | The ids of the story's comments, in ranked display order.
+Score   | `int`       | The story's score
+Time    | `int64`     | Creation date of the story in Unix Time
+Timestamp   | `time.Time`     | Creation date of the story
+Title   | `string`    | The story's title
+URL     | `string`    | The URL of the story
+Type    | `string`    | The type of item ("story")
+Poll | `int` | Associated Poll
+Parts | `int` | Associated Poll Options
 
 ##### Story
 Field | Type | Description
@@ -32,6 +48,7 @@ Descendants | `int`   | The total comment count
 Kids    | `[]int`     | The ids of the story's comments, in ranked display order.
 Score   | `int`       | The story's score
 Time    | `int64`     | Creation date of the story in Unix Time
+Timestamp   | `time.Time`     | Creation date of the story
 Title   | `string`    | The story's title
 URL     | `string`    | The URL of the story
 Type    | `string`    | The type of item ("story")
@@ -44,6 +61,7 @@ ID      | `int`       | This comments's item id
 Kids    | `[]int`     | The ids of the story's comments, in ranked display order.
 Parent  | `int`       | The comment's parent (another comment or the original story)
 Time    | `int64`     | Creation date of the comment in Unix Time
+Timestamp   | `time.Time`     | Creation date of the story
 Text    | `string`    | The comment's text
 Type    | `string`    | The type of item ("comment")
 
@@ -56,6 +74,7 @@ Descendants | `int`   | The total comment count
 Kids    | `[]int`     | The ids of the poll's comments, in ranked display order.
 Score   | `int`       | The poll's score
 Time    | `int64`     | Creation date of the poll in Unix Time
+Timestamp   | `time.Time`     | Creation date of the story
 Title   | `string`    | The poll's title
 URL     | `string`    | The URL of the poll
 Type    | `string`    | The type of item ("poll")
@@ -68,6 +87,7 @@ By      | `string`    | The username of the pollopt's author
 ID      | `int`       | This pollopt's item id
 Poll    | `int`       | The pollopt's parent (the poll it belongs to)
 Time    | `int64`     | Creation date of the pollopt in Unix Time
+Timestamp   | `time.Time`     | Creation date of the story
 Text    | `string`    | The pollopt's text
 Type    | `string`    | The type of item ("pollopt")
 
@@ -139,14 +159,13 @@ func main() {
     }
 
     // Get the details of the current max item.
-    maxItem, err := c.Item(maxID)
-    //...
-    switch maxItem.(type) {
-        case *hnapi.Story:
-            //...
-        case *hnapi.Comment:
-            //...
-    }
+    maxItem, err := c.GetItem(maxID)
+    // ...
+
+    id := 478932 // Some comment ID.
+    comment, err := c.GetComment(id)
+    fmt.Println(comment.By)
+    // ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Descendants | `int`   | The total comment count
 Kids    | `[]int`     | The ids of the story's comments, in ranked display order.
 Score   | `int`       | The story's score
 Time    | `int64`     | Creation date of the story in Unix Time
-Timestamp   | `time.Time`     | Creation date of the story
+Timestamp   | `time.Time`     | Creation date of the item
 Title   | `string`    | The story's title
 URL     | `string`    | The URL of the story
 Type    | `string`    | The type of item ("story")
@@ -61,7 +61,7 @@ ID      | `int`       | This comments's item id
 Kids    | `[]int`     | The ids of the story's comments, in ranked display order.
 Parent  | `int`       | The comment's parent (another comment or the original story)
 Time    | `int64`     | Creation date of the comment in Unix Time
-Timestamp   | `time.Time`     | Creation date of the story
+Timestamp   | `time.Time`     | Creation date of the comment
 Text    | `string`    | The comment's text
 Type    | `string`    | The type of item ("comment")
 
@@ -74,7 +74,7 @@ Descendants | `int`   | The total comment count
 Kids    | `[]int`     | The ids of the poll's comments, in ranked display order.
 Score   | `int`       | The poll's score
 Time    | `int64`     | Creation date of the poll in Unix Time
-Timestamp   | `time.Time`     | Creation date of the story
+Timestamp   | `time.Time`     | Creation date of the poll
 Title   | `string`    | The poll's title
 URL     | `string`    | The URL of the poll
 Type    | `string`    | The type of item ("poll")
@@ -87,7 +87,7 @@ By      | `string`    | The username of the pollopt's author
 ID      | `int`       | This pollopt's item id
 Poll    | `int`       | The pollopt's parent (the poll it belongs to)
 Time    | `int64`     | Creation date of the pollopt in Unix Time
-Timestamp   | `time.Time`     | Creation date of the story
+Timestamp   | `time.Time`     | Creation date of the pollopt
 Text    | `string`    | The pollopt's text
 Type    | `string`    | The type of item ("pollopt")
 

--- a/cmd/go-hn-cli/cmd/item.go
+++ b/cmd/go-hn-cli/cmd/item.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/hoenn/go-hn/pkg/hnapi"
 	"github.com/spf13/cobra"
 )
 
@@ -22,10 +23,37 @@ var getItemCmd = &cobra.Command{
 	Short: "Get an item by ID from the hackernews api",
 	Long:  "Gets an item (Story, Comment, Poll, PollOpt) from the hacker news api by its item ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		item, err := client.Item(itemID)
+		item, err := client.GetItem(itemID)
 		if err != nil {
 			errorMsgWithExit(err)
 		}
-		fmt.Print(prettyPrint(item))
+		switch item.Type {
+		case hnapi.StoryItem, hnapi.JobItem, hnapi.AskItem:
+			s, err := hnapi.ItemToStory(item)
+			if err != nil {
+				errorMsgWithExit(fmt.Errorf("could not read story item: %w", err))
+			}
+			fmt.Print(prettyPrint(s))
+		case hnapi.CommentItem:
+			c, err := hnapi.ItemToComment(item)
+			if err != nil {
+				errorMsgWithExit(fmt.Errorf("could not read comment item: %w", err))
+			}
+			fmt.Print(prettyPrint(c))
+		case hnapi.PollItem:
+			p, err := hnapi.ItemToPoll(item)
+			if err != nil {
+				errorMsgWithExit(fmt.Errorf("could not read poll item: %w", err))
+			}
+			fmt.Print(prettyPrint(p))
+		case hnapi.PollOptItem:
+			p, err := hnapi.ItemToPollOpt(item)
+			if err != nil {
+				errorMsgWithExit(fmt.Errorf("could not read pollopt item: %w", err))
+			}
+			fmt.Print(prettyPrint(p))
+		default:
+			fmt.Println(prettyPrint(item))
+		}
 	},
 }

--- a/pkg/hnapi/hnapi.go
+++ b/pkg/hnapi/hnapi.go
@@ -33,6 +33,9 @@ func NewHNClientWithURL(url string) *HNClient {
 	}
 }
 
+// Deprecated: Item is deprecated. Use GetItem or a more specialized method like GetComment instead.
+// This was deprecated because it pushed type casting into client code. There are now helper like
+// GetStory and ItemToComment to avoid returning an interface{} for clients to deal with.
 // Item issues a GET request on the /item/<id> path and creates a struct
 // from the response body.
 // It returns an empty interface to be asserted into one of the hnapi types
@@ -52,41 +55,184 @@ func (h *HNClient) Item(id string) (interface{}, error) {
 		return nil, fmt.Errorf("could not read response body: %w", err)
 	}
 
-	var t msgWrapper
-	if err := json.Unmarshal(body, &t); err != nil {
+	var i Item
+	if err := json.Unmarshal(body, &i); err != nil {
 		return nil, fmt.Errorf("could not unmarshal response body: %w", err)
 	}
 	var res interface{}
-	switch t.Type {
-	case "story", "job", "ask":
+	switch i.Type {
+	case StoryItem, JobItem, AskItem:
 		s := &Story{}
 		if err := json.Unmarshal(body, s); err != nil {
 			return nil, err
 		}
 		res = s
-	case "comment":
+	case CommentItem:
 		c := &Comment{}
 		if err := json.Unmarshal(body, c); err != nil {
 			return nil, err
 		}
 		res = c
-	case "poll":
+	case PollItem:
 		p := &Poll{}
 		if err := json.Unmarshal(body, p); err != nil {
 			return nil, err
 		}
 		res = p
-	case "pollopt":
+	case PollOptItem:
 		p := &PollOpt{}
 		if err := json.Unmarshal(body, p); err != nil {
 			return nil, err
 		}
 		res = p
 	default:
-		return nil, fmt.Errorf("unknown item type, open a github issue: %w", err)
+		return nil, fmt.Errorf("unknown item type: '%s'", i.Type)
 	}
 
 	return res, nil
+}
+
+const (
+	CommentItem = "comment"
+	PollItem    = "poll"
+	PollOptItem = "pollopt"
+	JobItem     = "job"
+	AskItem     = "ask"
+	StoryItem   = "story"
+)
+
+var storyItemTypes = map[string]bool{
+	JobItem:   true,
+	AskItem:   true,
+	StoryItem: true,
+}
+
+// GetItem returns an *Item from the API.
+func (h *HNClient) GetItem(id string) (*Item, error) {
+	url := h.objURLString("item", id)
+	resp, err := h.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("could not make GET request for item: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non 200 response code: %w", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body: %w", err)
+	}
+
+	i := &Item{}
+	if err := json.Unmarshal(body, i); err != nil {
+		return nil, fmt.Errorf("could not unmarshal response body: %w", err)
+	}
+	return i, nil
+}
+
+// ItemToComment converts an Item into a Comment.
+func ItemToComment(item *Item) (*Comment, error) {
+	if item.Type != CommentItem {
+		return nil, fmt.Errorf("item is not a comment")
+	}
+	return &Comment{
+		By:     item.By,
+		ID:     item.ID,
+		Kids:   item.Kids,
+		Parent: item.Parent,
+		Text:   item.Text,
+		Time:   item.Time,
+		Type:   item.Type,
+	}, nil
+}
+
+// GetComment is a helper function that gets an Item and converts it to a Comment or errors.
+func (h *HNClient) GetComment(id string) (*Comment, error) {
+	item, err := h.GetItem(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not get comment item: %w", err)
+	}
+	return ItemToComment(item)
+}
+
+// ItemToStory converts an Item into a Story.
+func ItemToStory(item *Item) (*Story, error) {
+	if _, ok := storyItemTypes[item.Type]; !ok {
+		return nil, fmt.Errorf("item is not a story")
+	}
+	return &Story{
+		By:          item.By,
+		Descendants: item.Descendants,
+		ID:          item.ID,
+		Kids:        item.Kids,
+		Score:       item.Score,
+		Time:        item.Time,
+		Title:       item.Title,
+		Type:        item.Type,
+		URL:         item.URL,
+	}, nil
+}
+
+// GetStory is a helper function that gets an Item and converts it to a Story or errors.
+func (h *HNClient) GetStory(id string) (*Story, error) {
+	item, err := h.GetItem(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not get story item: %w", err)
+	}
+	return ItemToStory(item)
+}
+
+// ItemToPoll converts an Item into a Poll.
+func ItemToPoll(item *Item) (*Poll, error) {
+	if item.Type != PollItem {
+		return nil, fmt.Errorf("item is not a poll")
+	}
+	return &Poll{
+		By:          item.By,
+		Descendants: item.Descendants,
+		ID:          item.ID,
+		Kids:        item.Kids,
+		Parts:       item.Parts,
+		Score:       item.Score,
+		Text:        item.Text,
+		Time:        item.Time,
+		Title:       item.Title,
+		Type:        item.Type,
+	}, nil
+}
+
+// GetPoll is a helper function that gets an Item and converts it to a Poll or errors.
+func (h *HNClient) GetPoll(id string) (*Poll, error) {
+	item, err := h.GetItem(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not get poll item: %w", err)
+	}
+	return ItemToPoll(item)
+}
+
+// ItemToPollOpt converts an Item into a PollOpt.
+func ItemToPollOpt(item *Item) (*PollOpt, error) {
+	if item.Type != PollOptItem {
+		return nil, fmt.Errorf("item is not a pollopt")
+	}
+	return &PollOpt{
+		By:    item.By,
+		ID:    item.ID,
+		Poll:  item.Poll,
+		Score: item.Score,
+		Text:  item.Text,
+		Time:  item.Time,
+		Type:  item.Type,
+	}, nil
+}
+
+// GetPollOpt is a helper function that gets an Item and converts it to a Pollopt or errors.
+func (h *HNClient) GetPollOpt(id string) (*PollOpt, error) {
+	item, err := h.GetItem(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not get pollopt item: %w", err)
+	}
+	return ItemToPollOpt(item)
 }
 
 // User issues a GET request on the /user/<id> path and
@@ -239,6 +385,26 @@ type HNUser struct {
 
 type msgWrapper struct {
 	Type string
+}
+
+// Item represents a HackerNews API item. Its properties are a superset of
+// Story, Comment, Poll, and Pollopt types.
+type Item struct {
+	ID          int
+	Deleted     bool
+	Type        string
+	By          string
+	Time        int64
+	Text        string
+	Dead        bool
+	Parent      int
+	Poll        int
+	Kids        []int
+	URL         string
+	Score       int
+	Title       string
+	Parts       []int
+	Descendants int
 }
 
 // Comment represents a HackerNews comment on a story.

--- a/pkg/hnapi/hnapi.go
+++ b/pkg/hnapi/hnapi.go
@@ -390,10 +390,6 @@ type HNUser struct {
 	Submitted []int
 }
 
-type msgWrapper struct {
-	Type string
-}
-
 // Item represents a HackerNews API item. Its properties are a superset of
 // Story, Comment, Poll, and Pollopt types.
 type Item struct {

--- a/pkg/hnapi/hnapi.go
+++ b/pkg/hnapi/hnapi.go
@@ -35,7 +35,7 @@ func NewHNClientWithURL(url string) *HNClient {
 }
 
 // Deprecated: Item is deprecated. Use GetItem or a more specialized method like GetComment instead.
-// This was deprecated because it pushed type casting into client code. There are now helper like
+// This was deprecated because it pushed type assertion into client code. There are now helpers like
 // GetStory and ItemToComment to avoid returning an interface{} for clients to deal with.
 // Item issues a GET request on the /item/<id> path and creates a struct
 // from the response body.
@@ -139,13 +139,14 @@ func ItemToComment(item *Item) (*Comment, error) {
 		return nil, fmt.Errorf("item is not a comment")
 	}
 	return &Comment{
-		By:     item.By,
-		ID:     item.ID,
-		Kids:   item.Kids,
-		Parent: item.Parent,
-		Text:   item.Text,
-		Time:   item.Time,
-		Type:   item.Type,
+		By:        item.By,
+		ID:        item.ID,
+		Kids:      item.Kids,
+		Parent:    item.Parent,
+		Text:      item.Text,
+		Time:      item.Time,
+		Timestamp: item.Timestamp,
+		Type:      item.Type,
 	}, nil
 }
 
@@ -170,6 +171,7 @@ func ItemToStory(item *Item) (*Story, error) {
 		Kids:        item.Kids,
 		Score:       item.Score,
 		Time:        item.Time,
+		Timestamp:   item.Timestamp,
 		Title:       item.Title,
 		Type:        item.Type,
 		URL:         item.URL,
@@ -199,6 +201,7 @@ func ItemToPoll(item *Item) (*Poll, error) {
 		Score:       item.Score,
 		Text:        item.Text,
 		Time:        item.Time,
+		Timestamp:   item.Timestamp,
 		Title:       item.Title,
 		Type:        item.Type,
 	}, nil
@@ -219,13 +222,14 @@ func ItemToPollOpt(item *Item) (*PollOpt, error) {
 		return nil, fmt.Errorf("item is not a pollopt")
 	}
 	return &PollOpt{
-		By:    item.By,
-		ID:    item.ID,
-		Poll:  item.Poll,
-		Score: item.Score,
-		Text:  item.Text,
-		Time:  item.Time,
-		Type:  item.Type,
+		By:        item.By,
+		ID:        item.ID,
+		Poll:      item.Poll,
+		Score:     item.Score,
+		Text:      item.Text,
+		Time:      item.Time,
+		Timestamp: item.Timestamp,
+		Type:      item.Type,
 	}, nil
 }
 
@@ -413,13 +417,14 @@ type Item struct {
 
 // Comment represents a HackerNews comment on a story.
 type Comment struct {
-	By     string
-	ID     int
-	Kids   []int
-	Parent int
-	Text   string
-	Time   int64
-	Type   string
+	By        string
+	ID        int
+	Kids      []int
+	Parent    int
+	Text      string
+	Time      int64
+	Timestamp time.Time
+	Type      string
 }
 
 // Story represents a HackerNews submitted story.
@@ -430,6 +435,7 @@ type Story struct {
 	Kids        []int
 	Score       int
 	Time        int64
+	Timestamp   time.Time
 	Title       string
 	Type        string
 	URL         string
@@ -446,17 +452,19 @@ type Poll struct {
 	Score       int
 	Text        string
 	Time        int64
+	Timestamp   time.Time
 	Title       string
 	Type        string
 }
 
 // PollOpt represents the poll options from a given poll.
 type PollOpt struct {
-	By    string
-	ID    int
-	Poll  int
-	Score int
-	Text  string
-	Time  int64
-	Type  string
+	By        string
+	ID        int
+	Poll      int
+	Score     int
+	Text      string
+	Time      int64
+	Timestamp time.Time
+	Type      string
 }

--- a/pkg/hnapi/hnapi.go
+++ b/pkg/hnapi/hnapi.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 const hnAddr = "https://hacker-news.firebaseio.com/v0"
@@ -127,6 +128,8 @@ func (h *HNClient) GetItem(id string) (*Item, error) {
 	if err := json.Unmarshal(body, i); err != nil {
 		return nil, fmt.Errorf("could not unmarshal response body: %w", err)
 	}
+
+	i.Timestamp = time.Unix(i.Time, 0)
 	return i, nil
 }
 
@@ -395,6 +398,7 @@ type Item struct {
 	Type        string
 	By          string
 	Time        int64
+	Timestamp   time.Time // Not directly available in the API.
 	Text        string
 	Dead        bool
 	Parent      int


### PR DESCRIPTION
Adds a new `Item` type that is a superset of the existing Item types. Adds helpers to reduce the need for client code to do type assertions. Should remain backwards compatible with a deprecation notice on `HNClient.Item`